### PR TITLE
Protect the /account/dashboard and /events/add routes

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import Header from './Header'
 import Footer from './Footer'
 import Showcase from './Showcase'
-import InfoBox from './InfoBox'
+// import InfoBox from './InfoBox'
 import styles from '@/styles/Layout.module.css'
 
 export default function Layout({ title, keywords, description, children }) {

--- a/context/AuthContext.js
+++ b/context/AuthContext.js
@@ -78,6 +78,12 @@ export const AuthProvider = ({ children }) => {
       setUser(data.user)
     } else {
       setUser(null)
+      if (
+        router.pathname === '/account/dashboard' ||
+        router.pathname === '/events/add'
+      ) {
+        router.push('/account/login')
+      }
     }
   }
 

--- a/pages/account/dashboard.js
+++ b/pages/account/dashboard.js
@@ -1,3 +1,5 @@
+import { useContext } from 'react'
+import AuthContext from '@/context/AuthContext'
 import { parseCookies } from '@/helpers/index'
 import { useRouter } from 'next/router'
 import Layout from '@/components/Layout'
@@ -7,6 +9,11 @@ import styles from '@/styles/Dashboard.module.css'
 
 export default function DashboardPage({ events, token }) {
   const router = useRouter()
+  const { user } = useContext(AuthContext)
+
+  if (!user) {
+    return null
+  }
 
   const deleteEvent = async (id) => {
     if (confirm('Are you sure?')) {
@@ -56,7 +63,7 @@ export async function getServerSideProps({ req }) {
   return {
     props: {
       events,
-      token,
+      token: token || '',
     },
   }
 }

--- a/pages/events/add.js
+++ b/pages/events/add.js
@@ -1,3 +1,5 @@
+import { useContext } from 'react'
+import AuthContext from '@/context/AuthContext'
 import { parseCookies } from '@/helpers/index'
 import { ToastContainer, toast } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.css'
@@ -9,6 +11,12 @@ import { API_URL } from '@/config/index'
 import styles from '@/styles/Form.module.css'
 
 export default function AddEventPage({ token }) {
+  const { user } = useContext(AuthContext)
+
+  if (!user) {
+    return null
+  }
+
   const [values, setValues] = useState({
     name: '',
     performers: '',
@@ -150,7 +158,7 @@ export async function getServerSideProps({ req }) {
 
   return {
     props: {
-      token,
+      token: token || '',
     },
   }
 }


### PR DESCRIPTION
Attempting to access the protected routes without authorization, by manually entering the related URLs in the browser's address bar, breaks the app for the /account/dashboard route and allows the display of the Add Event page.

With the following changes we conditionally redirect from inside the AuthContext wrapper when the checkUserLoggedIn() method fails to retrieve a user.

The changes in the protected pages pertain to avoiding breaking errors and flashing rendered content which occur before the useEffect  in the AuthContext fires.