### PR TITLE
Fixed: Event is still created if hasEmptyFields is true

### DIFF
--- a/pages/events/add.js
+++ b/pages/events/add.js
@@ -30,7 +30,7 @@ export default function AddEventPage({ token }) {
     )
 
     if (hasEmptyFields) {
-      toast.error('Please fill in all fields')
+      return toast.error('Please fill in all fields')
     }
 
     const res = await fetch(`${API_URL}/events`, {


### PR DESCRIPTION
Without a return statement at line 33, if any or all of the fields are empty and the add event form is submitted, the event is still created after the toast is displayed and disappears.
Adding the return statement will stop the execution of the handleSubmit function at the line 33 - toast.error('Please fill in all fields')
Hence it will prevent the event from being created.