### PR TITLE
fix: allow refresh the dashboard without complete page reloading after deleting an event

### DIFF
--- a/pages/account/dashboard.js
+++ b/pages/account/dashboard.js
@@ -22,7 +22,8 @@ export default function DashboardPage({ events, token }) {
       if (!res.ok) {
         toast.error(data.message)
       } else {
-        router.reload()
+        // refresh without full page reloading
+        router.replace(router.asPath);
       }
     }
   }


### PR DESCRIPTION
Hi Brad, this is just a small change I make while studying the course.