### PR TITLE
fix: removed InfoBox import

### DIFF
--- a/components/Layout.js
+++ b/components/Layout.js
@@ -3,7 +3,6 @@ import { useRouter } from 'next/router'
 import Header from './Header'
 import Footer from './Footer'
 import Showcase from './Showcase'
-import InfoBox from './InfoBox'
 import styles from '@/styles/Layout.module.css'
 
 export default function Layout({ title, keywords, description, children }) {


### PR DESCRIPTION
The import statement for InfoBox was causing the app to crash since the file does not exist anymore. Removing this will resolve the issue